### PR TITLE
add missing persistqueue dependency

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -22,3 +22,4 @@ python-pptx
 alembic
 rocketchat-API
 mattermostdriver
+persistqueue


### PR DESCRIPTION
https://github.com/GerevAI/gerev/blob/c8ed67a928c283a234a6aa7cb656aa91571f76c1/app/index_queue.py#L5

```
  File "/home/teynar/projects/gerev/app/./main.py", line 20, in <module>
    from indexing.background_indexer import BackgroundIndexer
  File "/home/teynar/projects/gerev/app/./indexing/background_indexer.py", line 5, in <module>
    from index_queue import IndexQueue
  File "/home/teynar/projects/gerev/app/./index_queue.py", line 5, in <module>
    from persistqueue import SQLiteAckQueue
ModuleNotFoundError: No module named 'persistqueue'
```