### PR TITLE
Cross-platform support for getting a home directory path

### DIFF
--- a/app/paths.py
+++ b/app/paths.py
@@ -3,7 +3,7 @@ import os
 
 IS_IN_DOCKER = os.geteuid() == 0
 
-STORAGE_PATH = Path('/opt/storage/') if IS_IN_DOCKER else Path(f'/home/{os.getlogin()}/.gerev/storage/')
+STORAGE_PATH = Path('/opt/storage/') if IS_IN_DOCKER else Path(f'{Path.home()}/.gerev/storage/')
 
 if not STORAGE_PATH.exists():
     STORAGE_PATH.mkdir(parents=True)


### PR DESCRIPTION
Although GerevAI is most likely going to be running on a Linux environment, it would still be nice to be able to run it on other environments such as macOS or Windows for development and/or testing purposes. This can be achieved by simply replacing `/home/{os.getlogin()` with `Path.home()`. I've noticed `pathlib.Path` is already in use, so we might as well use it to get the home directory path for the current user.