### PR TITLE
fix/windows-compatabilty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.9
 
+ENV DOCKER_DEPLOYMENT=1
+
 RUN pip install torch
 
 COPY ./app/requirements.txt /tmp/requirements.txt

--- a/app/data_source/api/dynamic_loader.py
+++ b/app/data_source/api/dynamic_loader.py
@@ -39,8 +39,6 @@ class DynamicLoader:
 
     @staticmethod
     def get_class(file_path: str, class_name: str):
-        
-        module_name = file_path.replace("/", ".").replace(".py", "")
         loader = importlib.machinery.SourceFileLoader(class_name, file_path)
         module = loader.load_module()
         try:

--- a/app/data_source/api/dynamic_loader.py
+++ b/app/data_source/api/dynamic_loader.py
@@ -19,7 +19,7 @@ class DynamicLoader:
     This class is used to dynamically load classes from files.
     Specifically, it is used to load data sources from the data_source/sources directory.
     """
-    SOURCES_PATH = 'data_source/sources'
+    SOURCES_PATH = os.path.join('data_source', 'sources')
 
     @staticmethod
     def extract_classes(file_path: str):
@@ -39,8 +39,10 @@ class DynamicLoader:
 
     @staticmethod
     def get_class(file_path: str, class_name: str):
+        
         module_name = file_path.replace("/", ".").replace(".py", "")
-        module = importlib.import_module(module_name)
+        loader = importlib.machinery.SourceFileLoader(class_name, file_path)
+        module = loader.load_module()
         try:
             return getattr(module, class_name)
         except AttributeError:

--- a/app/paths.py
+++ b/app/paths.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import os
 
-IS_IN_DOCKER = os.geteuid() == 0
+IS_IN_DOCKER = os.environ.get('DOCKER_DEPLOYMENT', False)
 
 STORAGE_PATH = Path('/opt/storage/') if IS_IN_DOCKER else Path(f'/home/{os.getlogin()}/.gerev/storage/')
 


### PR DESCRIPTION
### Fixes
* Changed `import_module` to `SourceFileLoader`
* Now using `os.path.join` where path generation is needed
* Added `DOCKER_DEPLOYMENT` env var instead of `os.geteuid() == 0` as this won't work on windows

### TODO

- [x] Test on docker

It works on docker as well as the original :)